### PR TITLE
Qt need an additional entry in the $PATH variable on osx

### DIFF
--- a/.ci/build_deps.sh
+++ b/.ci/build_deps.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -ev
-
 case $TRAVIS_OS_NAME in
     osx)
         # Build and install YCM

--- a/.ci/install_deps.sh
+++ b/.ci/install_deps.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -ev
-
 case $TRAVIS_OS_NAME in
     linux)
         apt-get update
@@ -22,6 +20,7 @@ case $TRAVIS_OS_NAME in
         brew tap robotology/cask
         brew tap homebrew/science
         brew install eigen ipopt yarp qt
+        export PATH="/usr/local/opt/qt/bin/:$PATH"
     ;;
     *) exit 1
     ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
         || travis_terminate 1
       docker commit baseimage imagewithbindeps || travis_terminate 1
     elif [[ "$TRAVIS_OS_NAME" = "osx" ]] ; then
-      sh $PROJECT_DIR_ABS/.ci/install_deps.sh || travis_terminate 1
+      source $PROJECT_DIR_ABS/.ci/install_deps.sh
     fi
 
 before_script:
@@ -78,7 +78,7 @@ before_script:
         || travis_terminate 1
       docker commit imagewithbindeps imagewithalldeps || travis_terminate 1
     elif [[ "$TRAVIS_OS_NAME" = "osx" ]] ; then
-      sh $PROJECT_DIR_ABS/.ci/build_deps.sh || travis_terminate 1
+      source $PROJECT_DIR_ABS/.ci/build_deps.sh
     fi
 
   # Run CMake into the persistent $PROJECT_DIR_ABS folder


### PR DESCRIPTION
Forgot to set the `$PATH` in the 73d31e269f3627c31ca82b15798efa9d2e159850 commit.

Moreover, running the script through `sh` spawns a new bash process, and the variables set in the script are lost after its execution. Sourcing the script fixes this behavior.

For future reference, we should also be careful of setting `ccache` in external scripts that are not sourced.